### PR TITLE
Fix display name and DNS upstreams dropped during deep-link import

### DIFF
--- a/lib/data/datasources/local_sources/server_datasource_impl.dart
+++ b/lib/data/datasources/local_sources/server_datasource_impl.dart
@@ -256,7 +256,15 @@ class ServerDataSourceImpl implements ServerDataSource {
   }) async {
     final configuration = await deepLinkManager.getConfigurationByBase64(base64: base64);
 
+    // Prefer the human-readable name carried by the deep-link payload (TLV
+    // tag 0x0C); fall back to the host name so the imported card never shows
+    // a blank title for older deep links that omit the field.
+    final String displayName = configuration.endpoint.name.isNotEmpty
+        ? configuration.endpoint.name
+        : configuration.endpoint.hostName;
+
     return ServerData.empty(
+      name: displayName,
       ipAddress: configuration.endpoint.addresses.first,
       domain: configuration.endpoint.hostName,
       username: configuration.endpoint.username,

--- a/plugins/vpn_plugin/lib/domain/configuration_encoder.dart
+++ b/plugins/vpn_plugin/lib/domain/configuration_encoder.dart
@@ -245,7 +245,15 @@ final class ConfigurationDecoder extends Converter<String, Configuration> {
     final bool postQuantumGroupEnabled = top.getBool(ConfigurationCodecKeys.postQuantumGroupEnabled) ?? false;
 
     final List<String> exclusions = top.getStringList(ConfigurationCodecKeys.exclusions) ?? const <String>[];
-    final List<String> dnsUpStreams = top.getStringList(ConfigurationCodecKeys.dnsUpStreams) ?? const <String>[];
+
+    // The deep-link FFI (`trusttunnel_deeplink_decode`) serializes
+    // `dns_upstreams` inside the `[endpoint]` table, while [ConfigurationEncoder]
+    // historically writes the same key at the top level for the native VPN
+    // backend. Read from `[endpoint]` first to honor the deep-link spec, then
+    // fall back to the top level so existing producers keep working.
+    final List<String> dnsUpStreams = endpoint.getStringList(ConfigurationCodecKeys.dnsUpStreams)
+        ?? top.getStringList(ConfigurationCodecKeys.dnsUpStreams)
+        ?? const <String>[];
 
     final String hostName = endpoint.getString(ConfigurationCodecKeys.hostname) ?? '';
     final List<String> addresses = endpoint.getStringList(ConfigurationCodecKeys.addresses) ?? const <String>[];

--- a/plugins/vpn_plugin/lib/domain/configuration_encoder.dart
+++ b/plugins/vpn_plugin/lib/domain/configuration_encoder.dart
@@ -99,6 +99,13 @@ abstract final class ConfigurationCodecKeys {
   /// Endpoint anti-DPI toggle key.
   static const antiDpi = 'anti_dpi';
 
+  /// Endpoint human-readable display name key.
+  ///
+  /// Carried by the deep-link payload as TLV tag `0x0C` (`Name`) per the
+  /// TrustTunnel deep-link specification, and serialized by the Rust FFI
+  /// (`trusttunnel_deeplink_decode`) inside the `[endpoint]` table.
+  static const name = 'name';
+
   // Tun keys
   /// TUN included routes list key.
   static const includedRoutes = 'included_routes';
@@ -272,6 +279,7 @@ final class ConfigurationDecoder extends Converter<String, Configuration> {
     final String upstreamFallbackProtocolStr =
         endpoint.getString(ConfigurationCodecKeys.upstreamFallbackProtocol) ?? '';
     final bool antiDpi = endpoint.getBool(ConfigurationCodecKeys.antiDpi) ?? false;
+    final String name = endpoint.getString(ConfigurationCodecKeys.name) ?? '';
 
     final List<String> includedRoutes =
         tun.getStringList(ConfigurationCodecKeys.includedRoutes) ?? IniConst.defaultTunRoutes;
@@ -320,6 +328,7 @@ final class ConfigurationDecoder extends Converter<String, Configuration> {
         skipVerification: skipVerification,
         certificate: certificate,
         antiDpi: antiDpi,
+        name: name,
       ),
       tun: Tun(
         includedRoutes: includedRoutes,

--- a/plugins/vpn_plugin/lib/models/endpoint.dart
+++ b/plugins/vpn_plugin/lib/models/endpoint.dart
@@ -119,11 +119,21 @@ final class Endpoint {
 
   final String customSni;
 
+  /// {@template endpoint_name}
+  /// Human-readable server name carried by the deep-link payload.
+  ///
+  /// Sourced from the optional TLV tag `0x0C` (`Name`) defined in the
+  /// TrustTunnel deep-link specification. When the deep link does not carry a
+  /// name, this field is empty and callers fall back to other identifiers
+  /// (typically [hostName]) when displaying the server.
+  /// {@endtemplate}
+  final String name;
+
   /// {@macro endpoint}
   ///
   /// Defaults are intentionally permissive:
   /// - [addresses], [dnsUpStreams] and [exclusions] default to empty lists.
-  /// - [clientRandom] and [certificate] default to empty strings.
+  /// - [clientRandom], [certificate] and [name] default to empty strings.
   /// - [skipVerification] and [antiDpi] default to `false`.
   /// - [upStreamFallbackProtocol] defaults to `null` (no explicit fallback).
   Endpoint({
@@ -133,6 +143,7 @@ final class Endpoint {
     this.clientRandom = '',
     this.certificate = '',
     this.customSni = '',
+    this.name = '',
     this.upStreamFallbackProtocol,
     this.antiDpi = false,
     this.skipVerification = false,
@@ -145,7 +156,7 @@ final class Endpoint {
 
   @override
   String toString() =>
-      'Endpoint(addresses: $addresses, dnsUpStreams: $dnsUpStreams, exclusions: $exclusions, hostName: $hostName, username: $username, password: $password, clientRandom: $clientRandom, certificate: $certificate, upStreamProtocol: $upStreamProtocol, upStreamFallbackProtocol: $upStreamFallbackProtocol, antiDpi: $antiDpi, hasIpv6: $hasIpv6, skipVerification: $skipVerification)';
+      'Endpoint(addresses: $addresses, dnsUpStreams: $dnsUpStreams, exclusions: $exclusions, hostName: $hostName, username: $username, password: $password, clientRandom: $clientRandom, certificate: $certificate, upStreamProtocol: $upStreamProtocol, upStreamFallbackProtocol: $upStreamFallbackProtocol, antiDpi: $antiDpi, hasIpv6: $hasIpv6, skipVerification: $skipVerification, name: $name)';
 
   @override
   bool operator ==(covariant Endpoint other) {
@@ -163,7 +174,8 @@ final class Endpoint {
         other.upStreamFallbackProtocol == upStreamFallbackProtocol &&
         other.antiDpi == antiDpi &&
         other.hasIpv6 == hasIpv6 &&
-        other.skipVerification == skipVerification;
+        other.skipVerification == skipVerification &&
+        other.name == name;
   }
 
   @override
@@ -181,5 +193,6 @@ final class Endpoint {
     antiDpi.hashCode,
     hasIpv6.hashCode,
     skipVerification.hashCode,
+    name.hashCode,
   ]);
 }


### PR DESCRIPTION
## Related Issue

Closes #54

## Summary

`tt://` deep links can carry a human-readable server name (TLV tag `0x0C`) and DNS upstreams (TLV tag `0x0D`), and `trusttunnel_deeplink_decode` already parses both into the `[endpoint]` TOML it returns to the Flutter side. The import path then drops both fields:

* `ConfigurationDecoder` reads `dns_upstreams` from the top-level section, while the Rust FFI writes it inside the `[endpoint]` table — so the list is always empty after import.
* `Endpoint` had no `name` field at all, the codec had no `name` key, and `ServerDataSourceImpl.getServerByBase64` constructed `ServerData.empty(...)` without passing a name, so imported servers landed with a blank card title.

The Flutter side already has `ServerData.name`, the `name TEXT NOT NULL` column in the Drift `servers` table, and the card title binding to `serverData.name` — only the import-path wiring is new.

Verified end-to-end on the iOS App Store build (`1.1.0+6361`); root cause is unchanged in `master` HEAD (`1.2.0+6671`). Full data-flow trace and code citations are in the linked issue.

## Changes

Two atomic commits, one per fix:

- **`Fix DNS upstreams dropped during deep-link import`** (1 file, +9/-1)
  In `plugins/vpn_plugin/lib/domain/configuration_encoder.dart`, read `dns_upstreams` from the `[endpoint]` section first and fall back to the top-level section so existing producers keep working. The encoder side intentionally stays on the top level so the wire format consumed by the native VPN backend via `VpnPluginImpl.start` / `updateConfiguration` is unchanged.

- **`Fix display name dropped during deep-link import`** (3 files, +33/-3)
  - Add `Endpoint.name` in `plugins/vpn_plugin/lib/models/endpoint.dart`, defaulting to `''` so existing constructions in `lib/data/datasources/native_sources/vpn_datasource.dart` need no changes.
  - Add a `ConfigurationCodecKeys.name` constant and read it from the `[endpoint]` section in `ConfigurationDecoder`, passing it through to the `Endpoint(...)` constructor.
  - In `ServerDataSourceImpl.getServerByBase64`, pass `name: configuration.endpoint.name` to `ServerData.empty(...)`, falling back to `configuration.endpoint.hostName` so older deep links without TLV `0x0C` still produce a non-blank card title.

## Notes for reviewers

- **Asymmetric codec is intentional.** The decoder reads `dns_upstreams` from `[endpoint]` (with top-level fallback), while the encoder still writes the key at top level. Reason: `_codec.encode(...)` is consumed by the native VPN backend in `VpnPluginImpl.start` / `updateConfiguration`, and changing where the encoder writes the key risks breaking that path. The encoder and decoder are never paired in a round-trip in current code, so the asymmetry is invisible to callers. Happy to also flip the encoder side if you'd prefer symmetry — just say the word and I'll add a third commit.
- **No DB migration, no UI changes, no native (Kotlin / Swift / Rust) changes.** The display-name UI binding already exists; only the data plumbing was missing.
- **Each commit is independently revertable.**
- **Cross-reference:** TrustTunnel/TrustTunnel#107 covers the same symptom but was filed against the protocol repo. Linking the FlutterClient issue here is the right home.

## Checklist

- [ ] Code generation is up to date (`make init`) — **needs CI / reviewer verification**: my local Dart SDK is 3.9.2 but this project requires 3.10.1+, so I could not run `make init` end-to-end. The changes don't touch any codegen-producing source, so no regeneration should be necessary, but please confirm in CI.
- [x] Dart analysis passes with no issues — verified for the touched plugin files via `dart analyze plugins/vpn_plugin/lib/models/endpoint.dart plugins/vpn_plugin/lib/domain/configuration_encoder.dart` (no issues). The main-app file (`server_datasource_impl.dart`) couldn't be analyzed locally due to the SDK version gap, but the change is 7 lines, well-typed against verified APIs (`ServerData.empty(name:)`, `Endpoint.name`, `Endpoint.hostName`).
- [x] Documentation updated — added doc-comments for `Endpoint.name` and `ConfigurationCodecKeys.name` referencing the deep-link spec and TLV tag.
- [x] No secrets or credentials committed.
