### PR TITLE
feat(android): implement split tunneling (per-app proxy) UI

### DIFF
--- a/lib/data/datasources/local_sources/settings_datasource_impl.dart
+++ b/lib/data/datasources/local_sources/settings_datasource_impl.dart
@@ -1,4 +1,5 @@
 import 'package:drift/drift.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:trusttunnel/data/database/app_database.dart' as db;
 import 'package:trusttunnel/data/datasources/settings_datasource.dart';
 
@@ -37,5 +38,41 @@ class SettingsDataSourceImpl implements SettingsDataSource {
         ),
       ),
     );
+  }
+
+  @override
+  Future<void> setPerAppProxy(bool enabled) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('per_app_proxy', enabled);
+  }
+
+  @override
+  Future<bool> getPerAppProxy() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool('per_app_proxy') ?? false;
+  }
+
+  @override
+  Future<void> setBypassApps(bool bypass) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('bypass_apps', bypass);
+  }
+
+  @override
+  Future<bool> getBypassApps() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool('bypass_apps') ?? false;
+  }
+
+  @override
+  Future<void> setProxyApps(List<String> apps) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList('proxy_apps', apps);
+  }
+
+  @override
+  Future<List<String>> getProxyApps() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getStringList('proxy_apps') ?? [];
   }
 }

--- a/lib/data/datasources/native_sources/vpn_datasource_impl.dart
+++ b/lib/data/datasources/native_sources/vpn_datasource_impl.dart
@@ -4,6 +4,7 @@ import 'package:trusttunnel/common/extensions/model_extensions.dart';
 import 'package:trusttunnel/common/utils/upstream_protocol_encoder.dart';
 import 'package:trusttunnel/common/utils/validation_utils.dart';
 import 'package:trusttunnel/common/utils/vpn_mode_encoder.dart';
+import 'package:trusttunnel/data/datasources/settings_datasource.dart';
 import 'package:trusttunnel/data/datasources/vpn_datasource.dart';
 import 'package:trusttunnel/data/model/routing_mode.dart';
 import 'package:trusttunnel/data/model/routing_profile_data.dart';
@@ -33,11 +34,14 @@ import 'package:vpn_plugin/vpn_plugin.dart';
 /// {@endtemplate}
 class VpnDataSourceImpl implements VpnDataSource {
   final VpnPlugin _platformApi;
+  final SettingsDataSource _settingsDataSource;
 
   /// {@macro vpn_data_source_impl}
   VpnDataSourceImpl({
     required VpnPlugin vpnPlugin,
-  }) : _platformApi = vpnPlugin;
+    required SettingsDataSource settingsDataSource,
+  })  : _platformApi = vpnPlugin,
+        _settingsDataSource = settingsDataSource;
 
   /// {@macro vpn_data_source_state_stream}
   ///
@@ -84,7 +88,7 @@ class VpnDataSourceImpl implements VpnDataSource {
     required ServerData server,
     required RoutingProfileData routingProfile,
     required List<String> excludedRoutes,
-  }) {
+  }) async {
     final exclusions = _getExclusionsByMode(routingProfile);
 
     final endPoint = Endpoint(
@@ -106,6 +110,10 @@ class VpnDataSourceImpl implements VpnDataSource {
       ),
     );
 
+    final perAppProxy = await _settingsDataSource.getPerAppProxy();
+    final bypassApps = await _settingsDataSource.getBypassApps();
+    final proxyApps = await _settingsDataSource.getProxyApps();
+
     return _platformApi.start(
       configuration: Configuration(
         vpnMode: VpnModeEncoder().convert(
@@ -114,6 +122,9 @@ class VpnDataSourceImpl implements VpnDataSource {
         endpoint: endPoint,
         tun: Tun(
           excludedRoutes: excludedRoutes,
+          perAppProxy: perAppProxy,
+          bypassApps: bypassApps,
+          proxyApps: proxyApps,
         ),
         socks: const Socks(),
       ),
@@ -139,7 +150,7 @@ class VpnDataSourceImpl implements VpnDataSource {
     required ServerData server,
     required RoutingProfileData routingProfile,
     required List<String> excludedRoutes,
-  }) {
+  }) async {
     final exclusions = _getExclusionsByMode(routingProfile);
 
     final endPoint = Endpoint(
@@ -161,6 +172,10 @@ class VpnDataSourceImpl implements VpnDataSource {
       clientRandom: server.tlsPrefix ?? '',
     );
 
+    final perAppProxy = await _settingsDataSource.getPerAppProxy();
+    final bypassApps = await _settingsDataSource.getBypassApps();
+    final proxyApps = await _settingsDataSource.getProxyApps();
+
     return _platformApi.updateConfiguration(
       configuration: Configuration(
         vpnMode: VpnModeEncoder().convert(
@@ -169,6 +184,9 @@ class VpnDataSourceImpl implements VpnDataSource {
         endpoint: endPoint,
         tun: Tun(
           excludedRoutes: excludedRoutes,
+          perAppProxy: perAppProxy,
+          bypassApps: bypassApps,
+          proxyApps: proxyApps,
         ),
         socks: const Socks(),
       ),

--- a/lib/data/datasources/settings_datasource.dart
+++ b/lib/data/datasources/settings_datasource.dart
@@ -17,4 +17,13 @@ abstract class SettingsDataSource {
   /// Loads the currently stored excluded routes list.
   /// {@endtemplate}
   Future<List<String>> getExcludedRoutes();
+
+  Future<void> setPerAppProxy(bool enabled);
+  Future<bool> getPerAppProxy();
+
+  Future<void> setBypassApps(bool bypass);
+  Future<bool> getBypassApps();
+
+  Future<void> setProxyApps(List<String> apps);
+  Future<List<String>> getProxyApps();
 }

--- a/lib/data/repository/settings_repository.dart
+++ b/lib/data/repository/settings_repository.dart
@@ -6,6 +6,15 @@ abstract class SettingsRepository {
   Future<void> setExcludedRoutes(List<String> routes);
 
   Future<List<String>> getExcludedRoutes();
+
+  Future<void> setPerAppProxy(bool enabled);
+  Future<bool> getPerAppProxy();
+
+  Future<void> setBypassApps(bool bypass);
+  Future<bool> getBypassApps();
+
+  Future<void> setProxyApps(List<String> apps);
+  Future<List<String>> getProxyApps();
 }
 
 class SettingsRepositoryImpl implements SettingsRepository {
@@ -20,4 +29,22 @@ class SettingsRepositoryImpl implements SettingsRepository {
 
   @override
   Future<void> setExcludedRoutes(List<String> routes) => _settingsDataSource.setExcludedRoutes(routes);
+
+  @override
+  Future<void> setPerAppProxy(bool enabled) => _settingsDataSource.setPerAppProxy(enabled);
+
+  @override
+  Future<bool> getPerAppProxy() => _settingsDataSource.getPerAppProxy();
+
+  @override
+  Future<void> setBypassApps(bool bypass) => _settingsDataSource.setBypassApps(bypass);
+
+  @override
+  Future<bool> getBypassApps() => _settingsDataSource.getBypassApps();
+
+  @override
+  Future<void> setProxyApps(List<String> apps) => _settingsDataSource.setProxyApps(apps);
+
+  @override
+  Future<List<String>> getProxyApps() => _settingsDataSource.getProxyApps();
 }

--- a/lib/di/model/dependency_factory.dart
+++ b/lib/di/model/dependency_factory.dart
@@ -79,7 +79,10 @@ class DependencyFactoryImpl implements DependencyFactory {
   );
 
   @override
-  VpnDataSource get vpnDataSource => _vpnDataSource ??= VpnDataSourceImpl(vpnPlugin: vpnPlugin);
+  VpnDataSource get vpnDataSource => _vpnDataSource ??= VpnDataSourceImpl(
+    vpnPlugin: vpnPlugin,
+    settingsDataSource: settingsDataSource,
+  );
 
   @override
   CertificateDataSource get certificateDataSource => _certificateDataSource ??= CertificateDataSourceImpl(

--- a/lib/feature/settings/per_app_proxy/widgets/per_app_proxy_screen.dart
+++ b/lib/feature/settings/per_app_proxy/widgets/per_app_proxy_screen.dart
@@ -1,0 +1,362 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:installed_apps/app_info.dart';
+import 'package:installed_apps/installed_apps.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:trusttunnel/widgets/custom_app_bar.dart';
+import 'package:trusttunnel/widgets/scaffold_wrapper.dart';
+import 'package:trusttunnel/feature/vpn/widgets/vpn_scope.dart';
+import 'package:trusttunnel/data/model/vpn_state.dart';
+import 'package:trusttunnel/feature/server/servers/widget/scope/servers_scope.dart';
+import 'package:trusttunnel/feature/server/servers/widget/scope/servers_scope_aspect.dart';
+import 'package:trusttunnel/feature/routing/routing/widgets/scope/routing_scope.dart';
+import 'package:trusttunnel/feature/routing/routing/widgets/scope/routing_scope_aspect.dart';
+import 'package:trusttunnel/feature/settings/excluded_routes/widgets/scope/excluded_routes_scope.dart';
+import 'package:trusttunnel/feature/settings/excluded_routes/widgets/scope/excluded_routes_aspect.dart';
+import 'package:collection/collection.dart';
+
+class PerAppProxyScreen extends StatefulWidget {
+  const PerAppProxyScreen({super.key});
+
+  @override
+  State<PerAppProxyScreen> createState() => _PerAppProxyScreenState();
+}
+
+class _PerAppProxyScreenState extends State<PerAppProxyScreen> {
+  bool _isLoading = true;
+  bool _perAppProxy = false;
+  bool _bypassApps = false;
+  bool _needsRestart = false;
+  
+  List<AppInfo> _allApps = [];
+  List<AppInfo> _displayedApps = [];
+  Set<String> _selectedApps = {};
+  
+  final TextEditingController _searchController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _loadData();
+    _searchController.addListener(_filterApps);
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadData() async {
+    setState(() => _isLoading = true);
+    
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      
+      // Update UI with saved settings immediately so the toggles don't flicker
+      setState(() {
+        _perAppProxy = prefs.getBool('per_app_proxy') ?? false;
+        _bypassApps = prefs.getBool('bypass_apps') ?? false;
+        _selectedApps = (prefs.getStringList('proxy_apps') ?? []).toSet();
+      });
+      
+      // Fetch installed apps (excluding system apps, with icons)
+      final apps = await InstalledApps.getInstalledApps(excludeSystemApps: true, withIcon: true);
+      
+      apps.sort((a, b) {
+        final aSelected = _selectedApps.contains(a.packageName);
+        final bSelected = _selectedApps.contains(b.packageName);
+        if (aSelected && !bSelected) return -1;
+        if (!aSelected && bSelected) return 1;
+        return (a.name ?? '').compareTo(b.name ?? '');
+      });
+      
+      setState(() {
+        _allApps = apps;
+        _displayedApps = List.from(_allApps);
+      });
+    } catch (e) {
+      // Ignore errors for now
+    } finally {
+      if (mounted) {
+        setState(() => _isLoading = false);
+      }
+    }
+  }
+
+  void _markNeedsRestart() {
+    final vpn = VpnScope.vpnControllerMaybeOf(context, listen: false);
+    if (vpn?.state == VpnState.connected && !_needsRestart) {
+      setState(() {
+        _needsRestart = true;
+      });
+    }
+  }
+
+  Future<void> _saveSettings() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('per_app_proxy', _perAppProxy);
+    await prefs.setBool('bypass_apps', _bypassApps);
+    await prefs.setStringList('proxy_apps', _selectedApps.toList());
+    _markNeedsRestart();
+  }
+
+  Future<void> _restartVpn() async {
+    final vpn = VpnScope.vpnControllerMaybeOf(context, listen: false);
+    if (vpn == null) return;
+
+    final serverScope = ServersScope.controllerOf(context, aspect: ServersScopeAspect.selectedServer);
+    final routingScope = RoutingScope.controllerOf(context, aspect: RoutingScopeAspect.profiles);
+    final excludedRoutesScope = ExcludedRoutesScope.controllerOf(context, aspect: ExcludedRoutesAspect.routes);
+
+    final server = serverScope.selectedServer;
+    final routingProfile = routingScope.routingList.firstWhereOrNull((e) => e.id == server?.serverData.routingProfileId);
+    final excludedRoutes = excludedRoutesScope.excludedRoutes;
+
+    if (server != null && routingProfile != null) {
+      // Temporarily clear the banner while restarting
+      setState(() => _needsRestart = false);
+      
+      // Stop and restart
+      await vpn.stop();
+      // small delay to let platform settle
+      await Future.delayed(const Duration(milliseconds: 500));
+      
+      if (mounted) {
+        await vpn.start(
+          server: server,
+          routingProfile: routingProfile,
+          excludedRoutes: excludedRoutes ?? [],
+        );
+      }
+    }
+  }
+
+  void _filterApps() {
+    final query = _searchController.text.toLowerCase();
+    setState(() {
+      if (query.isEmpty) {
+        _displayedApps = List.from(_allApps);
+      } else {
+        _displayedApps = _allApps.where((app) {
+          return (app.name ?? '').toLowerCase().contains(query) ||
+                 (app.packageName ?? '').toLowerCase().contains(query);
+        }).toList();
+      }
+    });
+  }
+
+  void _selectAll() {
+    setState(() {
+      for (var app in _displayedApps) {
+        if (app.packageName != null) {
+          _selectedApps.add(app.packageName!);
+        }
+      }
+    });
+    _saveSettings();
+  }
+
+  void _invertSelection() {
+    setState(() {
+      for (var app in _displayedApps) {
+        if (app.packageName != null) {
+          if (_selectedApps.contains(app.packageName)) {
+            _selectedApps.remove(app.packageName);
+          } else {
+            _selectedApps.add(app.packageName!);
+          }
+        }
+      }
+    });
+    _saveSettings();
+  }
+
+  Future<void> _exportToClipboard() async {
+    final buffer = StringBuffer();
+    buffer.writeln(_bypassApps.toString());
+    for (var app in _selectedApps) {
+      buffer.writeln(app);
+    }
+    await Clipboard.setData(ClipboardData(text: buffer.toString()));
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Exported to clipboard')),
+      );
+    }
+  }
+
+  Future<void> _importFromClipboard() async {
+    final data = await Clipboard.getData('text/plain');
+    if (data?.text == null) return;
+    
+    final lines = data!.text!.split('\n').map((e) => e.trim()).where((e) => e.isNotEmpty).toList();
+    if (lines.isEmpty) return;
+    
+    final bypassStr = lines.first.toLowerCase();
+    if (bypassStr != 'true' && bypassStr != 'false') {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Invalid format: First line must be true or false')),
+        );
+      }
+      return;
+    }
+    
+    setState(() {
+      _bypassApps = bypassStr == 'true';
+      _selectedApps.clear();
+      if (lines.length > 1) {
+        _selectedApps.addAll(lines.sublist(1));
+      }
+    });
+    await _saveSettings();
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Imported successfully')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ScaffoldWrapper(
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Per-app Proxy'),
+          actions: [
+            PopupMenuButton<String>(
+              onSelected: (value) {
+                switch (value) {
+                  case 'select_all':
+                    _selectAll();
+                    break;
+                  case 'invert':
+                    _invertSelection();
+                    break;
+                  case 'export':
+                    _exportToClipboard();
+                    break;
+                  case 'import':
+                    _importFromClipboard();
+                    break;
+                }
+              },
+              itemBuilder: (context) => [
+                const PopupMenuItem(value: 'select_all', child: Text('Select All Visible')),
+                const PopupMenuItem(value: 'invert', child: Text('Invert Selection')),
+                const PopupMenuItem(value: 'export', child: Text('Export to Clipboard')),
+                const PopupMenuItem(value: 'import', child: Text('Import from Clipboard')),
+              ],
+            ),
+          ],
+        ),
+        body: Column(
+          children: [
+            if (_needsRestart)
+              Container(
+                color: Colors.orange.withOpacity(0.2),
+                padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+                child: Row(
+                  children: [
+                    const Expanded(
+                      child: Text(
+                        'Restart required to apply changes.',
+                        style: TextStyle(fontSize: 13),
+                      ),
+                    ),
+                    TextButton(
+                      onPressed: _restartVpn,
+                      child: const Text('Restart'),
+                    ),
+                  ],
+                ),
+              ),
+            Expanded(
+              child: ListTileTheme(
+                contentPadding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 0.0),
+                dense: true,
+                child: Column(
+                  children: [
+                    SwitchListTile(
+                      visualDensity: const VisualDensity(horizontal: 0, vertical: -4),
+                      title: const Text('Enable Per-app Proxy'),
+                      value: _perAppProxy,
+                      onChanged: (val) {
+                        setState(() => _perAppProxy = val);
+                        _saveSettings();
+                      },
+                    ),
+                    if (_perAppProxy) ...[
+                      ListTile(
+                        visualDensity: const VisualDensity(horizontal: 0, vertical: -4),
+                        title: const Text('Route'),
+                        trailing: DropdownButton<bool>(
+                          value: _bypassApps,
+                          items: const [
+                            DropdownMenuItem(value: false, child: Text('Proxy Selected')),
+                            DropdownMenuItem(value: true, child: Text('Bypass Selected')),
+                          ],
+                          onChanged: (val) {
+                            if (val != null) {
+                              setState(() => _bypassApps = val);
+                              _saveSettings();
+                            }
+                          },
+                        ),
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+                        child: TextField(
+                          controller: _searchController,
+                          decoration: const InputDecoration(
+                            labelText: 'Search Apps',
+                            prefixIcon: Icon(Icons.search),
+                            border: OutlineInputBorder(),
+                            isDense: true,
+                            contentPadding: EdgeInsets.all(12),
+                          ),
+                        ),
+                      ),
+                      Expanded(
+                        child: _isLoading 
+                          ? const Center(child: CircularProgressIndicator())
+                          : ListView.builder(
+                              itemCount: _displayedApps.length,
+                              itemBuilder: (context, index) {
+                                final app = _displayedApps[index];
+                                final isSelected = _selectedApps.contains(app.packageName);
+                                return CheckboxListTile(
+                                  visualDensity: const VisualDensity(horizontal: 0, vertical: -4),
+                                  secondary: app.icon != null 
+                                    ? Image.memory(app.icon!, width: 32, height: 32)
+                                    : const Icon(Icons.android, size: 32),
+                                  title: Text(app.name ?? 'Unknown', style: const TextStyle(fontSize: 14)),
+                                  subtitle: Text(app.packageName ?? '', style: const TextStyle(fontSize: 12)),
+                                  value: isSelected,
+                                  onChanged: (val) {
+                                    if (val == null || app.packageName == null) return;
+                                    setState(() {
+                                      if (val) {
+                                        _selectedApps.add(app.packageName!);
+                                      } else {
+                                        _selectedApps.remove(app.packageName!);
+                                      }
+                                    });
+                                    _saveSettings();
+                                  },
+                                );
+                              },
+                            ),
+                      ),
+                    ]
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/feature/settings/settings/settings_screen.dart
+++ b/lib/feature/settings/settings/settings_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:trusttunnel/common/extensions/context_extensions.dart';
 import 'package:trusttunnel/common/localization/localization.dart';
@@ -9,8 +10,21 @@ import 'package:trusttunnel/widgets/common/custom_arrow_list_tile.dart';
 import 'package:trusttunnel/widgets/custom_app_bar.dart';
 import 'package:trusttunnel/widgets/scaffold_wrapper.dart';
 
-class SettingsScreen extends StatelessWidget {
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:trusttunnel/feature/settings/per_app_proxy/widgets/per_app_proxy_screen.dart';
+
+class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key});
+
+  @override
+  State<SettingsScreen> createState() => _SettingsScreenState();
+}
+
+class _SettingsScreenState extends State<SettingsScreen> {
+  @override
+  void initState() {
+    super.initState();
+  }
 
   @override
   Widget build(BuildContext context) => ScaffoldWrapper(
@@ -30,6 +44,13 @@ class SettingsScreen extends StatelessWidget {
             onTap: () => _pushExcludedRoutesScreen(context),
           ),
           const Divider(),
+          if (Platform.isAndroid) ...[
+            CustomArrowListTile(
+              title: 'Per-app proxy', // Hardcoded english per user's request
+              onTap: () => _pushPerAppProxyScreen(context),
+            ),
+            const Divider(),
+          ],
           CustomArrowListTile(
             title: context.ln.followUsOnGithub,
             onTap: _openGithubOrganization,
@@ -50,6 +71,10 @@ class SettingsScreen extends StatelessWidget {
 
   void _pushExcludedRoutesScreen(BuildContext context) => context.push(
     const ExcludedRoutesScreen(),
+  );
+
+  void _pushPerAppProxyScreen(BuildContext context) => context.push(
+    const PerAppProxyScreen(),
   );
 
   void _openGithubOrganization() => UrlUtils.openWebPage(UrlUtils.githubTrustTunnelTeam);

--- a/plugins/vpn_plugin/lib/domain/configuration_codec.dart
+++ b/plugins/vpn_plugin/lib/domain/configuration_codec.dart
@@ -112,6 +112,15 @@ abstract final class ConfigurationCodecKeys {
   /// TUN MTU key.
   static const mtuSize = 'mtu_size';
 
+  /// TUN per-app proxy enabled key.
+  static const perAppProxy = 'per_app_proxy';
+
+  /// TUN bypass apps toggle key.
+  static const bypassApps = 'bypass_apps';
+
+  /// TUN proxy apps list key.
+  static const proxyApps = 'proxy_apps';
+
   // Socks keys
   /// SOCKS listener bind address key.
   static const socksAddress = 'address';
@@ -196,6 +205,9 @@ final class ConfigurationEncoder extends Converter<Configuration, String> {
     tun.setStringList(ConfigurationCodecKeys.includedRoutes, config.tun.includedRoutes);
     tun.setStringList(ConfigurationCodecKeys.excludedRoutes, config.tun.excludedRoutes);
     tun.setInt(ConfigurationCodecKeys.mtuSize, config.tun.mtuSize);
+    tun.setBool(ConfigurationCodecKeys.perAppProxy, config.tun.perAppProxy);
+    tun.setBool(ConfigurationCodecKeys.bypassApps, config.tun.bypassApps);
+    tun.setStringList(ConfigurationCodecKeys.proxyApps, config.tun.proxyApps);
 
     // final IniSection socks = document.section(ConfigurationCodecKeys.socksSection);
     // socks.setString(ConfigurationCodecKeys.socksAddress, config.socks.address);
@@ -280,6 +292,9 @@ final class ConfigurationDecoder extends Converter<String, Configuration> {
         tun.getStringList(ConfigurationCodecKeys.includedRoutes) ?? IniConst.defaultTunRoutes;
     final List<String> excludedRoutes = tun.getStringList(ConfigurationCodecKeys.excludedRoutes) ?? const <String>[];
     final int mtuSize = tun.getInt(ConfigurationCodecKeys.mtuSize) ?? IniConst.defaultTunMtu;
+    final bool perAppProxy = tun.getBool(ConfigurationCodecKeys.perAppProxy) ?? false;
+    final bool bypassApps = tun.getBool(ConfigurationCodecKeys.bypassApps) ?? false;
+    final List<String> proxyApps = tun.getStringList(ConfigurationCodecKeys.proxyApps) ?? const <String>[];
 
     final String socksAddress = socks.getString(ConfigurationCodecKeys.socksAddress) ?? IniConst.defaultSocksAddress;
     final String socksUsername = socks.getString(ConfigurationCodecKeys.socksUsername) ?? '';
@@ -329,6 +344,9 @@ final class ConfigurationDecoder extends Converter<String, Configuration> {
         includedRoutes: includedRoutes,
         excludedRoutes: excludedRoutes,
         mtuSize: mtuSize,
+        perAppProxy: perAppProxy,
+        bypassApps: bypassApps,
+        proxyApps: proxyApps,
       ),
       socks: Socks(
         address: socksAddress,

--- a/plugins/vpn_plugin/lib/models/tun.dart
+++ b/plugins/vpn_plugin/lib/models/tun.dart
@@ -33,6 +33,22 @@ final class Tun {
   /// {@endtemplate}
   final int mtuSize;
 
+  /// {@template tun_per_app_proxy}
+  /// Enables per-app proxying (split tunneling).
+  /// {@endtemplate}
+  final bool perAppProxy;
+
+  /// {@template tun_bypass_apps}
+  /// If true, the proxyApps list is treated as a bypass list.
+  /// If false, the proxyApps list is treated as an allowed list.
+  /// {@endtemplate}
+  final bool bypassApps;
+
+  /// {@template tun_proxy_apps}
+  /// List of package names to route through or bypass.
+  /// {@endtemplate}
+  final List<String> proxyApps;
+
   /// {@macro tun}
   const Tun({
     this.includedRoutes = const [
@@ -41,10 +57,13 @@ final class Tun {
     ],
     this.excludedRoutes = const [],
     this.mtuSize = 1280,
+    this.perAppProxy = false,
+    this.bypassApps = false,
+    this.proxyApps = const [],
   }) : assert(mtuSize > 0, 'mtuSize must be greater than 0');
 
   @override
-  String toString() => 'Tun(includedRoutes: $includedRoutes, excludedRoutes: $excludedRoutes, mtuSize: $mtuSize)';
+  String toString() => 'Tun(includedRoutes: $includedRoutes, excludedRoutes: $excludedRoutes, mtuSize: $mtuSize, perAppProxy: $perAppProxy, bypassApps: $bypassApps, proxyApps: $proxyApps)';
 
   @override
   bool operator ==(covariant Tun other) {
@@ -52,7 +71,10 @@ final class Tun {
 
     return listEquals(other.includedRoutes, includedRoutes) &&
         listEquals(other.excludedRoutes, excludedRoutes) &&
-        other.mtuSize == mtuSize;
+        other.mtuSize == mtuSize &&
+        other.perAppProxy == perAppProxy &&
+        other.bypassApps == bypassApps &&
+        listEquals(other.proxyApps, proxyApps);
   }
 
   @override
@@ -60,5 +82,8 @@ final class Tun {
     includedRoutes,
     excludedRoutes,
     mtuSize,
+    perAppProxy,
+    bypassApps,
+    proxyApps,
   ]);
 }


### PR DESCRIPTION
## Related Issue

Closes #27

## Summary

This PR introduces the UI and state management for the Android-specific Split Tunneling (Per-App Proxy) feature. 

*Depends on the native core PR: TrustTunnel/TrustTunnelClient#79*

## Changes

- **UI:** Created a new `PerAppProxyScreen` to display and filter installed Android apps using the `installed_apps` plugin.
- **Platform Check:** The "Per-app proxy" menu item in settings is strictly visible only on Android to prevent crashes or confusing UX on iOS/macOS.
- **Storage:** Added `SharedPreferences` logic in `SettingsDataSource` to persist the chosen per-app routing preferences.
- **Integration:** Modified `VpnDataSource` and `configuration_codec` to inject the routing preferences into the `Tun` plugin model before starting the tunnel.
- **UX:** Added a dynamic "Restart required" banner that prompts the user to apply changes if the VPN is currently active.

## Checklist

- [x] Code generation is up to date (`make init`)
- [x] Dart analysis passes with no issues
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed
